### PR TITLE
fix: duplicates points for no recorded points

### DIFF
--- a/pybads/function_logger/function_logger.py
+++ b/pybads/function_logger/function_logger.py
@@ -368,13 +368,14 @@ class FunctionLogger:
         if not record_duplicate_data:
             duplicate_flag = self.X == x
             if np.any(duplicate_flag):
-                if np.sum(duplicate_flag.all(axis=1)) > 1:
-                    raise ValueError("More than one match for duplicate entry.")
-                idx = np.argwhere(duplicate_flag)[0, 0]
-                N = self.n_evals[idx]
-                self.fun_eval_time[idx] = (N * self.fun_eval_time[idx] + fun_eval_time) / (N + 1)
-                self.n_evals[idx] += 1
-                return fval_orig, idx
+                # Since we do not record the new duplicate point in the training set
+                # and we might have more than one duplicate points (e.g for NON-heteroskedastic cases)
+                # we register the function evaluation time and increase the counter of function evaluations in the last duplicate
+                last_idx = np.argwhere(duplicate_flag.all(axis=1))[-1].item()
+                N = self.n_evals[last_idx]
+                self.fun_eval_time[last_idx] = (N * self.fun_eval_time[last_idx] + fun_eval_time) / (N + 1)
+                self.n_evals[last_idx] += 1
+                return fval_orig, last_idx
             else:
                 logging.getLogger("BADS").debug('function_logger: Asked to NOT record duplicate data, but NO duplicate points have found.')
                 


### PR DESCRIPTION
There was a wrong if condition and it was raising an error when duplicates were found when building the final estimator by sampling from the same point (i.e when not recording duplicate data in the function logger inputs).
The algorithm was raising the error because at the final steps of the optimization the algorithm added the same final point at least twice (like it was stuck and different function evaluations have been carried out at final incumbents)
Therefore the wrong code present when building the final estimator was arising the error when detecting duplicates.
This was a "rare" event because most of the time PyBADS didn't have the same points for the last incumbent during the final steps of the optimization.

Recall that the function logger has three cases when adding points:

1. the heteroskedastic case (we merge observation and estimate the new variance, the point is recorded)
2. each point is a new point (unknown-noise case, the point is recorded)
3. not recorded, we update the number of function evaluations and the time of function evaluation. The issue was in the recorded case