### PR TITLE
fix: Doc Makefile for missing directory

### DIFF
--- a/docsrc/Makefile
+++ b/docsrc/Makefile
@@ -25,7 +25,7 @@ github:
 
 clean:
 	@rm -rf ../docs/*
-	@rm -r _build
+	@if [ -d "./_build" ]; then rm -r _build; fi;
 
 .PHONY: help Makefile
 


### PR DESCRIPTION
Added a check in Makefile for  `_build` missing directory.
It can happen for example when the workspace is already clean. This issue is raised when the workplace is already empty and can cause the `doc workflow` to fail.