### PR TITLE
fix;bug: changed function from squeeze to flatten in variable transfo…

### DIFF
--- a/pybads/testing/bads/test_bads_optimization.py
+++ b/pybads/testing/bads/test_bads_optimization.py
@@ -54,6 +54,11 @@ def test_ellipsoid_opt():
     fun = lambda x: np.sum((np.atleast_2d(x) / np.arange(1, len(x) + 1) ** 2) ** 2)
     run_bads(fun, x0, LB, UB, PLB, PUB, tol_errs, f_min=0.0, assert_flag=True)
 
+def test_1D_opt():
+    D, x0, LB, UB, PLB, PUB, tol_errs = get_test_opt_conf(D=1)
+    fun = lambda x: np.sum((np.atleast_2d(x) / np.arange(1, len(x) + 1) ** 2) ** 2)
+    run_bads(fun, x0, LB, UB, PLB, PUB, tol_errs, f_min=0.0, assert_flag=True)
+
 def test_high_dim_opt():
     D, x0, LB, UB, PLB, PUB, tol_errs = get_test_opt_conf(D=60)
     fun = lambda x: np.sum((np.atleast_2d(x) / np.arange(1, len(x) + 1) ** 2) ** 2)

--- a/pybads/variable_transformer/variables_transformer.py
+++ b/pybads/variable_transformer/variables_transformer.py
@@ -148,7 +148,8 @@ class VariableTransformer:
 
         # A variable is converted to log scale if all bounds are positive and
         # the plausible range spans at least one order of magnitude
-        for i in np.argwhere(np.isnan(self.apply_log_t.squeeze())):
+        check_idx_log_t = np.argwhere(np.isnan(self.apply_log_t.flatten()))
+        for i in check_idx_log_t:
             self.apply_log_t[:, i] = (
                 np.all(
                     np.concatenate(
@@ -212,8 +213,8 @@ class VariableTransformer:
         tests = np.zeros(4)
         tests[0] = np.all(np.abs(ginv(g(lbtest)) - lbtest) < numeps)
         tests[1] = np.all(np.abs(ginv(g(ubtest)) - ubtest) < numeps)
-        tests[2] = np.all(np.abs(ginv(g(self.plb)) - self.plb) < numeps)
-        tests[3] = np.all(np.abs(ginv(g(self.pub)) - self.pub) < numeps)
+        tests[2] = np.all(np.abs(ginv(g(self.orig_plb)) - self.orig_plb) < numeps)
+        tests[3] = np.all(np.abs(ginv(g(self.orig_pub)) - self.orig_pub) < numeps)
         if not np.all(tests):
             raise ValueError("Cannot invert the transform to obtain the identity at the provided boundaries.")
 


### PR DESCRIPTION
 - Changed function from `np.squeeze` to `np.flatten` while checking the variable transformation; `np.squeeze` removed the dimension when not needed, indeed in the case of 1d dim was giving a scalar result, not a vector