### PR TITLE
fix: not number deprecated usage

### DIFF
--- a/pybads/bads/bads.py
+++ b/pybads/bads/bads.py
@@ -163,7 +163,7 @@ class BADS:
                  provided, plausible_lower_bounds and plausible_upper_bounds need to be specified."""
                 )
             else:
-                x0 = np.full((plausible_lower_bounds.shape), np.NaN)
+                x0 = np.full((plausible_lower_bounds.shape), np.nan)
 
         x0 = np.atleast_2d(x0)
         self.D = x0.shape[1]
@@ -597,7 +597,7 @@ class BADS:
 
         # Compute transformation of variables
         if self.options["nonlinear_scaling"]:
-            logflag = np.full((1, self.D), np.NaN)
+            logflag = np.full((1, self.D), np.nan)
             periodic_vars = self.options["periodic_vars"]
             if periodic_vars is not None and len(periodic_vars) != 0:
                 logflag[

--- a/pybads/bads/option_configs/advanced_bads_options.ini
+++ b/pybads/bads/option_configs/advanced_bads_options.ini
@@ -52,7 +52,7 @@ consecutive_skipping                     = True
 # Skip polling after successful search'
 skip_poll_after_search                     = True                  
 # Number of failed fcn evaluations before skipping is allowed'
-min_failed_poll_steps                      = np.Inf                
+min_failed_poll_steps                      = np.inf                
 # Accelerate mesh after this number of stalled iterations'
 accelerate_mesh_steps                     = 3                  
 # Move incumbent even after insufficient improvement
@@ -213,7 +213,7 @@ nsgp_max = 0
 # Max GP hyperparameter samples during warmup
 nsgp_maxwarmup = 8                           
 # Max GP hyperparameter samples during main algorithm
-nsgp_maxmain = np.Inf                        
+nsgp_maxmain = np.inf                        
 # Number of GP samples when GP is stable (0 = optimize)
 stable_gp_samples = 0                         
 # Tolerance for optimization of GP hyperparameters during active sampling
@@ -243,7 +243,7 @@ kl_gauss = True
 # Variational components during warmup
 k_warmup = 2                                 
 # Force stable GP hyperparameter sampling after reaching this number of components
-stable_gp_vpk = np.Inf                        
+stable_gp_vpk = np.inf                        
 # GP warping function type
 warp_func = 0                                
 # Slice sampler option for prior hyper-parameter sampling method

--- a/pybads/stats/get_hpd.py
+++ b/pybads/stats/get_hpd.py
@@ -40,6 +40,6 @@ def get_hpd(X: np.ndarray, y: np.ndarray, hpd_frac: float = 0.8):
     if hpd_N > 0:
         hpd_range = np.max(hpd_X, axis=0) - np.min(hpd_X, axis=0)
     else:
-        hpd_range = np.full((D), np.NaN)
+        hpd_range = np.full((D), np.nan)
 
     return hpd_X, hpd_y, hpd_range, indices

--- a/pybads/variable_transformer/variables_transformer.py
+++ b/pybads/variable_transformer/variables_transformer.py
@@ -97,7 +97,7 @@ class VariableTransformer:
         self.D = D
         # Nonlinear log transform
         if apply_log_t is None:
-            self.apply_log_t = np.full((1, self.D), np.NaN)
+            self.apply_log_t = np.full((1, self.D), np.nan)
         elif np.isscalar(apply_log_t):
             self.apply_log_t = (
                 self.apply_log_t * np.ones((1, self.D))


### PR DESCRIPTION
Patch for deprecated usage of `np.NaN` and `np.Inf`. 
